### PR TITLE
Adding several serial functions and unit tests for all print and println functions

### DIFF
--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -71,7 +71,7 @@ class Serial_ {
     static size_t println(long, int = DEC);
     static size_t println(unsigned long, int = DEC);
     static size_t println(double, int = 2);
-    static sizeMOCK_METHOD1_t println(void);
+    static size_t println(void);
 
     size_t write(uint8_t);
     size_t write(const char *str);

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -7,6 +7,8 @@
 #include <stdint.h>
 #include <gmock/gmock.h>
 
+#include <string>
+
 #define DEC 10
 #define HEX 16
 #define OCT 8
@@ -69,7 +71,7 @@ class Serial_ {
     static size_t println(long, int = DEC);
     static size_t println(unsigned long, int = DEC);
     static size_t println(double, int = 2);
-    static size_t println(void);
+    static sizeMOCK_METHOD1_t println(void);
 
     size_t write(uint8_t);
     size_t write(const char *str);
@@ -97,5 +99,27 @@ class Serial_ {
 
 SerialMock* serialMockInstance();
 void releaseSerialMock();
+
+
+/*
+ * Thsi is a helper class which can be Invoked on EXPECT_CALL to gather data
+ * from repeated calls to Serial functions. For example usage, see the unit
+ * tests in test/serial_unittest.cc
+ *
+ */
+class stringCapture {
+public:
+    stringCapture();
+    bool captureUInt8(uint8_t c);
+    bool captureUInt16(uint16_t c);
+    bool captureCStr(const uint8_t *buffer, size_t size);
+    void clear();
+    std::string get();
+
+private:
+    std::stringstream d;
+};
+
+
 
 #endif // SERIAL_H

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -101,25 +101,4 @@ SerialMock* serialMockInstance();
 void releaseSerialMock();
 
 
-/*
- * Thsi is a helper class which can be Invoked on EXPECT_CALL to gather data
- * from repeated calls to Serial functions. For example usage, see the unit
- * tests in test/serial_unittest.cc
- *
- */
-class stringCapture {
-  public:
-    stringCapture();
-    bool captureUInt8(uint8_t c);
-    bool captureUInt16(uint16_t c);
-    bool captureCStr(const uint8_t *buffer, size_t size);
-    void clear();
-    std::string get();
-
-  private:
-    std::stringstream d;
-};
-
-
-
 #endif // SERIAL_H

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -68,6 +68,9 @@ class Serial_ {
     static size_t println(double, int = 2);
     static size_t println(void);
 
+    size_t write(uint8_t);
+    size_t write(const char *str);
+
     uint8_t begin(uint16_t);
 
     static void flush();
@@ -76,8 +79,6 @@ class Serial_ {
     TODO: Not implemented yet.
     int getWriteError();
     void clearWriteError();
-    size_t write(uint8_t);
-    size_t write(const char *str);
     size_t write(const uint8_t *buffer, size_t size);
     static size_t print(const __FlashStringHelper *);
     static size_t print(const String &);

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -73,6 +73,7 @@ class Serial_ {
 
     size_t write(uint8_t);
     size_t write(const char *str);
+    size_t write(const uint8_t *buffer, size_t size);
 
     uint8_t begin(uint32_t);
 
@@ -85,7 +86,6 @@ class Serial_ {
     TODO: Not implemented yet.
     int getWriteError();
     void clearWriteError();
-    size_t write(const uint8_t *buffer, size_t size);
     static size_t print(const __FlashStringHelper *);
     static size_t print(const String &);
     static size_t print(const Printable&);

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -74,7 +74,7 @@ class Serial_ {
     size_t write(uint8_t);
     size_t write(const char *str);
 
-    uint8_t begin(uint16_t);
+    uint8_t begin(uint32_t);
 
     uint8_t available();
     uint8_t read();

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -36,6 +36,9 @@ class SerialMock {
 
     MOCK_METHOD1(begin, uint8_t(uint16_t));
 
+    MOCK_METHOD0(available, uint8_t());
+    MOCK_METHOD0(read, uint8_t());
+
     MOCK_METHOD0(flush, void());
 
     /* Not implemented yet
@@ -72,6 +75,9 @@ class Serial_ {
     size_t write(const char *str);
 
     uint8_t begin(uint16_t);
+
+    uint8_t available();
+    uint8_t read();
 
     static void flush();
 

--- a/include/arduino-mock/serial.h
+++ b/include/arduino-mock/serial.h
@@ -108,7 +108,7 @@ void releaseSerialMock();
  *
  */
 class stringCapture {
-public:
+  public:
     stringCapture();
     bool captureUInt8(uint8_t c);
     bool captureUInt16(uint16_t c);
@@ -116,7 +116,7 @@ public:
     void clear();
     std::string get();
 
-private:
+  private:
     std::stringstream d;
 };
 

--- a/include/arduino-mock/serialHelper.h
+++ b/include/arduino-mock/serialHelper.h
@@ -5,6 +5,9 @@
 #ifndef SERIALHELPER_H
 #define SERIALHELPER_H
 
+#include <stdint.h>
+#include <string>
+#include <sstream>
 
 /*
  * stringCapture

--- a/include/arduino-mock/serialHelper.h
+++ b/include/arduino-mock/serialHelper.h
@@ -1,0 +1,24 @@
+#ifndef SERIALHELPER_H
+#define SERIALHELPER_H
+
+/*
+ * This is a helper class which can be Invoked on EXPECT_CALL to gather data
+ * from repeated calls to Serial functions. For example usage, see the unit
+ * tests in test/serial_unittest.cc
+ *
+ */
+class stringCapture {
+  public:
+    stringCapture();
+    bool captureUInt8(uint8_t c);
+    bool captureUInt16(uint16_t c);
+    bool captureCStr(const uint8_t *buffer, size_t size);
+    void clear();
+    std::string get();
+
+  private:
+    std::stringstream d;
+};
+
+
+#endif // SERIALHELPER_H

--- a/include/arduino-mock/serialHelper.h
+++ b/include/arduino-mock/serialHelper.h
@@ -1,10 +1,22 @@
+/*
+ * serialHelper - helper functions for unittesting serial functions.
+ *
+ */
 #ifndef SERIALHELPER_H
 #define SERIALHELPER_H
 
+
 /*
+ * stringCapture
  * This is a helper class which can be Invoked on EXPECT_CALL to gather data
  * from repeated calls to Serial functions. For example usage, see the unit
  * tests in test/serial_unittest.cc
+ *
+ * Example usage:
+ *
+ * EXPECT_CALL(*sm, write(Matcher<const uint8_t*>(_), (_)))
+ *       .Times(AtLeast(1))
+ *       .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
  *
  */
 class stringCapture {

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -95,7 +95,7 @@ size_t Serial_::write(const char *str)
     return gSerialMock->write(str);
 }
 
-uint8_t Serial_::begin(uint16_t port) {
+uint8_t Serial_::begin(uint32_t port) {
   return gSerialMock->begin(port);
 }
 

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -85,6 +85,16 @@ size_t Serial_::println(void) {
   return gSerialMock->println();
 }
 
+size_t Serial_::write(uint8_t val)
+{
+    return gSerialMock->write(val);
+}
+
+size_t Serial_::write(const char *str)
+{
+    return gSerialMock->write(str);
+}
+
 uint8_t Serial_::begin(uint16_t port) {
   return gSerialMock->begin(port);
 }

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -116,3 +116,36 @@ uint8_t Serial_::read() {
   return gSerialMock->read();
 }
 
+
+stringCapture::stringCapture()
+    : d()
+{}
+
+bool stringCapture::captureUInt16(uint16_t c)
+{
+    d << c;
+    return true;
+}
+
+bool stringCapture::captureUInt8(uint8_t c)
+{
+    d << c;
+    return true;
+}
+
+bool stringCapture::captureCStr(const uint8_t *buffer, size_t size)
+{
+    d << std::string((const char*)buffer, size);
+    return true;
+}
+
+void stringCapture::clear()
+{
+    return d.str("");
+}
+
+std::string stringCapture::get()
+{
+    return d.str();
+}
+

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -115,8 +115,8 @@ uint8_t Serial_::read() {
 
 
 stringCapture::stringCapture()
-  : d()
-{}
+  : d() {
+}
 
 bool stringCapture::captureUInt16(uint16_t c) {
   d << c;

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -95,6 +95,11 @@ size_t Serial_::write(const char *str)
     return gSerialMock->write(str);
 }
 
+size_t Serial_::write(const uint8_t *buffer, size_t size)
+{
+    return gSerialMock->write(buffer, size);
+}
+
 uint8_t Serial_::begin(uint32_t port) {
   return gSerialMock->begin(port);
 }

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -102,3 +102,12 @@ uint8_t Serial_::begin(uint16_t port) {
 void Serial_::flush() {
   return gSerialMock->flush();
 }
+
+uint8_t Serial_::available() {
+  return gSerialMock->available();
+}
+
+uint8_t Serial_::read() {
+  return gSerialMock->read();
+}
+

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -85,19 +85,16 @@ size_t Serial_::println(void) {
   return gSerialMock->println();
 }
 
-size_t Serial_::write(uint8_t val)
-{
-    return gSerialMock->write(val);
+size_t Serial_::write(uint8_t val) {
+  return gSerialMock->write(val);
 }
 
-size_t Serial_::write(const char *str)
-{
-    return gSerialMock->write(str);
+size_t Serial_::write(const char *str) {
+  return gSerialMock->write(str);
 }
 
-size_t Serial_::write(const uint8_t *buffer, size_t size)
-{
-    return gSerialMock->write(buffer, size);
+size_t Serial_::write(const uint8_t *buffer, size_t size) {
+  return gSerialMock->write(buffer, size);
 }
 
 uint8_t Serial_::begin(uint32_t port) {
@@ -118,34 +115,29 @@ uint8_t Serial_::read() {
 
 
 stringCapture::stringCapture()
-    : d()
+  : d()
 {}
 
-bool stringCapture::captureUInt16(uint16_t c)
-{
-    d << c;
-    return true;
+bool stringCapture::captureUInt16(uint16_t c) {
+  d << c;
+  return true;
 }
 
-bool stringCapture::captureUInt8(uint8_t c)
-{
-    d << c;
-    return true;
+bool stringCapture::captureUInt8(uint8_t c) {
+  d << c;
+  return true;
 }
 
-bool stringCapture::captureCStr(const uint8_t *buffer, size_t size)
-{
-    d << std::string((const char*)buffer, size);
-    return true;
+bool stringCapture::captureCStr(const uint8_t *buffer, size_t size) {
+  d << std::string((const char*)buffer, size);
+  return true;
 }
 
-void stringCapture::clear()
-{
-    return d.str("");
+void stringCapture::clear() {
+  return d.str("");
 }
 
-std::string stringCapture::get()
-{
-    return d.str();
+std::string stringCapture::get() {
+  return d.str();
 }
 

--- a/src/serial.cc
+++ b/src/serial.cc
@@ -112,32 +112,3 @@ uint8_t Serial_::available() {
 uint8_t Serial_::read() {
   return gSerialMock->read();
 }
-
-
-stringCapture::stringCapture()
-  : d() {
-}
-
-bool stringCapture::captureUInt16(uint16_t c) {
-  d << c;
-  return true;
-}
-
-bool stringCapture::captureUInt8(uint8_t c) {
-  d << c;
-  return true;
-}
-
-bool stringCapture::captureCStr(const uint8_t *buffer, size_t size) {
-  d << std::string((const char*)buffer, size);
-  return true;
-}
-
-void stringCapture::clear() {
-  return d.str("");
-}
-
-std::string stringCapture::get() {
-  return d.str();
-}
-

--- a/src/serialHelper.cc
+++ b/src/serialHelper.cc
@@ -1,0 +1,29 @@
+#include "arduino-mock/serialHelper.h"
+
+stringCapture::stringCapture()
+  : d() {
+}
+
+bool stringCapture::captureUInt16(uint16_t c) {
+  d << c;
+  return true;
+}
+
+bool stringCapture::captureUInt8(uint8_t c) {
+  d << c;
+  return true;
+}
+
+bool stringCapture::captureCStr(const uint8_t *buffer, size_t size) {
+  d << std::string((const char*)buffer, size);
+  return true;
+}
+
+void stringCapture::clear() {
+  return d.str("");
+}
+
+std::string stringCapture::get() {
+  return d.str();
+}
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -44,7 +44,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread \
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = arduino_unittest wire_unittest serial_unittest spark_unittest eeprom_unittest wifi_unittest
+TESTS = arduino_unittest wire_unittest serial_unittest spark_unittest eeprom_unittest wifi_unittest serialHelper_unittest
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -112,6 +112,11 @@ serial.o : $(ARDUINO_MOCK_DIR)/include/arduino-mock/serial.h \
 	$(CXX) $(CPPFLAGS) -I$(ARDUINO_MOCK_DIR) $(CXXFLAGS) -c \
 		$(ARDUINO_MOCK_DIR)/src/serial.cc
 
+serialHelper.o : $(ARDUINO_MOCK_DIR)/include/arduino-mock/serialHelper.h \
+		$(ARDUINO_MOCK_DIR)/src/serialHelper.cc
+	$(CXX) $(CPPFLAGS) -I$(ARDUINO_MOCK_DIR) $(CXXFLAGS) -c \
+		$(ARDUINO_MOCK_DIR)/src/serialHelper.cc
+
 spark.o : $(ARDUINO_MOCK_DIR)/include/arduino-mock/spark.h \
 		$(ARDUINO_MOCK_DIR)/src/spark.cc
 	$(CXX) $(CPPFLAGS) -I$(ARDUINO_MOCK_DIR) $(CXXFLAGS) -c \
@@ -140,6 +145,15 @@ serial_unittest.o : $(TEST_DIR)/serial_unittest.cc \
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/serial_unittest.cc
 
 serial_unittest : serial_unittest.o \
+				gmock_main.a  \
+				arduino_mock_all.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@
+
+serialHelper_unittest.o : $(TEST_DIR)/serialHelper_unittest.cc \
+				$(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(TEST_DIR)/serialHelper_unittest.cc
+
+serialHelper_unittest : serialHelper_unittest.o \
 				gmock_main.a  \
 				arduino_mock_all.a
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $^ -o $@

--- a/test/serialHelper_unittest.cc
+++ b/test/serialHelper_unittest.cc
@@ -1,0 +1,79 @@
+#include "gtest/gtest.h"
+#include "arduino-mock/arduino.h"
+#include "arduino-mock/serial.h"
+
+#include "arduino-mock/serialHelper.h"
+
+Serial_ Serial;
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::Matcher;
+using ::testing::AtLeast;
+using ::testing::Invoke;
+
+
+TEST(serial, stringCapture1) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(1);
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('a'));
+
+  EXPECT_EQ(c.get(), std::string("a"));
+
+  // Clear data
+  c.clear();
+
+  EXPECT_EQ(c.get(), std::string(""));
+
+  // Insert new char
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('b'));
+
+  EXPECT_EQ(c.get(), std::string("b"));
+
+  releaseSerialMock();
+}
+
+
+TEST(serial, stringCapture2) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(5);
+  EXPECT_CALL(*serialMock, write(Matcher<const uint8_t *>(_), Matcher<size_t>(_)))
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
+  EXPECT_EQ(1, Serial.write((const uint8_t*)"abcde", 5));
+
+  EXPECT_EQ(c.get(), std::string("abcde"));
+
+}
+
+
+TEST(serial, stringCapture3) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(1);
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('a'));
+
+  EXPECT_EQ(c.get(), std::string("a"));
+
+  // Insert new char
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('b'));
+
+  EXPECT_EQ(c.get(), std::string("ab"));
+
+  releaseSerialMock();
+}

--- a/test/serial_unittest.cc
+++ b/test/serial_unittest.cc
@@ -7,10 +7,174 @@
 Serial_ Serial;
 
 using ::testing::Return;
-TEST(loop, pushed) {
+using ::testing::Matcher;
+
+
+// static size_t println(int, int = DEC);
+TEST(serial, println1) {
   SerialMock* serialMock = serialMockInstance();
-  EXPECT_CALL(*serialMock, println(1, 10));
-  Serial.println(1, 10);
+  EXPECT_CALL(*serialMock, println(1, 10))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(1, 10));
+  releaseSerialMock();
+}
+
+// static size_t println(const char[]);
+TEST(serial, println2) {
+  SerialMock* serialMock = serialMockInstance();
+  const char lala[] = "haha";
+  EXPECT_CALL(*serialMock, println(lala))
+          .WillRepeatedly(Return(4));
+  EXPECT_EQ(4, Serial.println(lala));
+  releaseSerialMock();
+}
+
+// static size_t println(char);
+TEST(serial, println3) {
+  SerialMock* serialMock = serialMockInstance();
+  char lala = 'a';
+  EXPECT_CALL(*serialMock, println(lala))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala));
+  releaseSerialMock();
+}
+
+//static size_t println(unsigned char, int = DEC);
+TEST(serial, println4) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned char lala = 'a';
+  EXPECT_CALL(*serialMock, println(lala, DEC))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala));
+  releaseSerialMock();
+}
+
+//static size_t println(unsigned int, int = DEC);
+TEST(serial, println5) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned int lala = 1234;
+  EXPECT_CALL(*serialMock, println(lala, DEC))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t println(long, int = DEC);
+TEST(serial, println6) {
+  SerialMock* serialMock = serialMockInstance();
+  long lala = 1234567;
+  EXPECT_CALL(*serialMock, println(lala, DEC))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t println(unsigned long, int = DEC);
+TEST(serial, println7) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned long lala = 2345678;
+  EXPECT_CALL(*serialMock, println(lala, DEC))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t println(double, int = 2);
+TEST(serial, println8) {
+  SerialMock* serialMock = serialMockInstance();
+  double lala = 3.14;
+  EXPECT_CALL(*serialMock, println(lala, 2))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println(lala, 2));
+  releaseSerialMock();
+}
+
+// static size_t println(void);
+TEST(serial, println9) {
+  SerialMock* serialMock = serialMockInstance();
+  EXPECT_CALL(*serialMock, println())
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.println());
+  releaseSerialMock();
+}
+
+// static size_t print(int, int = DEC);
+TEST(serial, print1) {
+  SerialMock* serialMock = serialMockInstance();
+  int lala = 123;
+  EXPECT_CALL(*serialMock, print(Matcher<int>(lala), Matcher<int>(10)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala, 10));
+  releaseSerialMock();
+}
+
+// static size_t print(const char[]);
+TEST(serial, print2) {
+  SerialMock* serialMock = serialMockInstance();
+  const char lala[] = "haha";
+  EXPECT_CALL(*serialMock, print(Matcher<const char*>(lala)))
+          .WillRepeatedly(Return(4));
+  EXPECT_EQ(4, Serial.print(lala));
+  releaseSerialMock();
+}
+
+// static size_t print(char);
+TEST(serial, print3) {
+  SerialMock* serialMock = serialMockInstance();
+  char lala = 'a';
+  EXPECT_CALL(*serialMock, print(Matcher<char>(lala)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala));
+  releaseSerialMock();
+}
+
+//static size_t print(unsigned char, int = DEC);
+TEST(serial, print4) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned char lala = 'a';
+  EXPECT_CALL(*serialMock, print(Matcher<unsigned char>(lala), Matcher<int>(DEC)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala));
+  releaseSerialMock();
+}
+
+//static size_t print(unsigned int, int = DEC);
+TEST(serial, print5) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned int lala = 1234;
+  EXPECT_CALL(*serialMock, print(Matcher<unsigned int>(lala), Matcher<int>(DEC)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t print(long, int = DEC);
+TEST(serial, print6) {
+  SerialMock* serialMock = serialMockInstance();
+  long lala = 1234567;
+  EXPECT_CALL(*serialMock, print(Matcher<long>(lala), Matcher<int>(DEC)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t print(unsigned long, int = DEC);
+TEST(serial, print7) {
+  SerialMock* serialMock = serialMockInstance();
+  unsigned long lala = 2345678;
+  EXPECT_CALL(*serialMock, print(Matcher<unsigned long>(lala), Matcher<int>(DEC)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala, DEC));
+  releaseSerialMock();
+}
+
+// static size_t println(double, int = 2);
+TEST(serial, print8) {
+  SerialMock* serialMock = serialMockInstance();
+  double lala = 3.14;
+  EXPECT_CALL(*serialMock, print(Matcher<double>(lala), Matcher<int>(2)))
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.print(lala, 2));
   releaseSerialMock();
 }
 
@@ -18,5 +182,36 @@ TEST(serial, flush) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, flush());
   Serial.flush();
+  releaseSerialMock();
+}
+
+TEST(serial, write1) {
+  SerialMock* serialMock = serialMockInstance();
+  EXPECT_CALL(*serialMock, write('a'));
+  Serial.write('a');
+  releaseSerialMock();
+}
+
+TEST(serial, available) {
+  SerialMock* serialMock = serialMockInstance();
+  EXPECT_CALL(*serialMock, available())
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.available());
+  releaseSerialMock();
+}
+
+TEST(serial, read1) {
+  SerialMock* serialMock = serialMockInstance();
+  EXPECT_CALL(*serialMock, read())
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.read());
+  releaseSerialMock();
+}
+
+TEST(serial, read2) {
+  SerialMock* serialMock = serialMockInstance();
+  EXPECT_CALL(*serialMock, read())
+          .WillRepeatedly(Return(1));
+  EXPECT_EQ(1, Serial.read());
   releaseSerialMock();
 }

--- a/test/serial_unittest.cc
+++ b/test/serial_unittest.cc
@@ -17,7 +17,7 @@ using ::testing::Invoke;
 TEST(serial, println1) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, println(1, 10))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(1, 10));
   releaseSerialMock();
 }
@@ -27,7 +27,7 @@ TEST(serial, println2) {
   SerialMock* serialMock = serialMockInstance();
   const char lala[] = "haha";
   EXPECT_CALL(*serialMock, println(lala))
-    .WillRepeatedly(Return(4));
+  .WillRepeatedly(Return(4));
   EXPECT_EQ(4, Serial.println(lala));
   releaseSerialMock();
 }
@@ -37,7 +37,7 @@ TEST(serial, println3) {
   SerialMock* serialMock = serialMockInstance();
   char lala = 'a';
   EXPECT_CALL(*serialMock, println(lala))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala));
   releaseSerialMock();
 }
@@ -47,7 +47,7 @@ TEST(serial, println4) {
   SerialMock* serialMock = serialMockInstance();
   unsigned char lala = 'a';
   EXPECT_CALL(*serialMock, println(lala, DEC))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala));
   releaseSerialMock();
 }
@@ -57,7 +57,7 @@ TEST(serial, println5) {
   SerialMock* serialMock = serialMockInstance();
   unsigned int lala = 1234;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -67,7 +67,7 @@ TEST(serial, println6) {
   SerialMock* serialMock = serialMockInstance();
   long lala = 1234567;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -77,7 +77,7 @@ TEST(serial, println7) {
   SerialMock* serialMock = serialMockInstance();
   unsigned long lala = 2345678;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -87,7 +87,7 @@ TEST(serial, println8) {
   SerialMock* serialMock = serialMockInstance();
   double lala = 3.14;
   EXPECT_CALL(*serialMock, println(lala, 2))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, 2));
   releaseSerialMock();
 }
@@ -96,7 +96,7 @@ TEST(serial, println8) {
 TEST(serial, println9) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, println())
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println());
   releaseSerialMock();
 }
@@ -106,7 +106,7 @@ TEST(serial, print1) {
   SerialMock* serialMock = serialMockInstance();
   int lala = 123;
   EXPECT_CALL(*serialMock, print(Matcher<int>(lala), Matcher<int>(10)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, 10));
   releaseSerialMock();
 }
@@ -116,7 +116,7 @@ TEST(serial, print2) {
   SerialMock* serialMock = serialMockInstance();
   const char lala[] = "haha";
   EXPECT_CALL(*serialMock, print(Matcher<const char*>(lala)))
-    .WillRepeatedly(Return(4));
+  .WillRepeatedly(Return(4));
   EXPECT_EQ(4, Serial.print(lala));
   releaseSerialMock();
 }
@@ -126,7 +126,7 @@ TEST(serial, print3) {
   SerialMock* serialMock = serialMockInstance();
   char lala = 'a';
   EXPECT_CALL(*serialMock, print(Matcher<char>(lala)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala));
   releaseSerialMock();
 }
@@ -136,7 +136,7 @@ TEST(serial, print4) {
   SerialMock* serialMock = serialMockInstance();
   unsigned char lala = 'a';
   EXPECT_CALL(*serialMock, print(Matcher<unsigned char>(lala), Matcher<int>(DEC)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala));
   releaseSerialMock();
 }
@@ -146,7 +146,7 @@ TEST(serial, print5) {
   SerialMock* serialMock = serialMockInstance();
   unsigned int lala = 1234;
   EXPECT_CALL(*serialMock, print(Matcher<unsigned int>(lala), Matcher<int>(DEC)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -156,7 +156,7 @@ TEST(serial, print6) {
   SerialMock* serialMock = serialMockInstance();
   long lala = 1234567;
   EXPECT_CALL(*serialMock, print(Matcher<long>(lala), Matcher<int>(DEC)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -166,7 +166,7 @@ TEST(serial, print7) {
   SerialMock* serialMock = serialMockInstance();
   unsigned long lala = 2345678;
   EXPECT_CALL(*serialMock, print(Matcher<unsigned long>(lala), Matcher<int>(DEC)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -176,7 +176,7 @@ TEST(serial, print8) {
   SerialMock* serialMock = serialMockInstance();
   double lala = 3.14;
   EXPECT_CALL(*serialMock, print(Matcher<double>(lala), Matcher<int>(2)))
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, 2));
   releaseSerialMock();
 }
@@ -198,7 +198,7 @@ TEST(serial, write1) {
 TEST(serial, available) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, available())
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.available());
   releaseSerialMock();
 }
@@ -206,7 +206,7 @@ TEST(serial, available) {
 TEST(serial, read1) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, read())
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
   releaseSerialMock();
 }
@@ -214,7 +214,7 @@ TEST(serial, read1) {
 TEST(serial, read2) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, read())
-    .WillRepeatedly(Return(1));
+  .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
   releaseSerialMock();
 }
@@ -227,7 +227,7 @@ TEST(serial, stringCapture1) {
 
   testing::DefaultValue<uint8_t>::Set(1);
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('a'));
 
   EXPECT_EQ(c.get(), std::string("a"));
@@ -239,7 +239,7 @@ TEST(serial, stringCapture1) {
 
   // Insert new char
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('b'));
 
   EXPECT_EQ(c.get(), std::string("b"));
@@ -255,7 +255,7 @@ TEST(serial, stringCapture2) {
 
   testing::DefaultValue<uint8_t>::Set(5);
   EXPECT_CALL(*serialMock, write(Matcher<const uint8_t *>(_), Matcher<size_t>(_)))
-    .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
   EXPECT_EQ(1, Serial.write((const uint8_t*)"abcde", 5));
 
   EXPECT_EQ(c.get(), std::string("abcde"));
@@ -270,14 +270,14 @@ TEST(serial, stringCapture3) {
 
   testing::DefaultValue<uint8_t>::Set(1);
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('a'));
 
   EXPECT_EQ(c.get(), std::string("a"));
 
   // Insert new char
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('b'));
 
   EXPECT_EQ(c.get(), std::string("ab"));

--- a/test/serial_unittest.cc
+++ b/test/serial_unittest.cc
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 #include "arduino-mock/arduino.h"
 #include "arduino-mock/serial.h"
+
 Serial_ Serial;
 
 using ::testing::_;
@@ -216,71 +217,5 @@ TEST(serial, read2) {
   EXPECT_CALL(*serialMock, read())
   .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
-  releaseSerialMock();
-}
-
-
-TEST(serial, stringCapture1) {
-  // Insert char first time
-  SerialMock* serialMock = serialMockInstance();
-  stringCapture c;
-
-  testing::DefaultValue<uint8_t>::Set(1);
-  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
-  EXPECT_EQ(1, Serial.write('a'));
-
-  EXPECT_EQ(c.get(), std::string("a"));
-
-  // Clear data
-  c.clear();
-
-  EXPECT_EQ(c.get(), std::string(""));
-
-  // Insert new char
-  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
-  EXPECT_EQ(1, Serial.write('b'));
-
-  EXPECT_EQ(c.get(), std::string("b"));
-
-  releaseSerialMock();
-}
-
-
-TEST(serial, stringCapture2) {
-  // Insert char first time
-  SerialMock* serialMock = serialMockInstance();
-  stringCapture c;
-
-  testing::DefaultValue<uint8_t>::Set(5);
-  EXPECT_CALL(*serialMock, write(Matcher<const uint8_t *>(_), Matcher<size_t>(_)))
-  .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
-  EXPECT_EQ(1, Serial.write((const uint8_t*)"abcde", 5));
-
-  EXPECT_EQ(c.get(), std::string("abcde"));
-
-}
-
-
-TEST(serial, stringCapture3) {
-  // Insert char first time
-  SerialMock* serialMock = serialMockInstance();
-  stringCapture c;
-
-  testing::DefaultValue<uint8_t>::Set(1);
-  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
-  EXPECT_EQ(1, Serial.write('a'));
-
-  EXPECT_EQ(c.get(), std::string("a"));
-
-  // Insert new char
-  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-  .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
-  EXPECT_EQ(1, Serial.write('b'));
-
-  EXPECT_EQ(c.get(), std::string("ab"));
-
   releaseSerialMock();
 }

--- a/test/serial_unittest.cc
+++ b/test/serial_unittest.cc
@@ -6,8 +6,11 @@
 #include "arduino-mock/serial.h"
 Serial_ Serial;
 
+using ::testing::_;
 using ::testing::Return;
 using ::testing::Matcher;
+using ::testing::AtLeast;
+using ::testing::Invoke;
 
 
 // static size_t println(int, int = DEC);
@@ -213,5 +216,71 @@ TEST(serial, read2) {
   EXPECT_CALL(*serialMock, read())
           .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
+  releaseSerialMock();
+}
+
+
+TEST(serial, stringCapture1) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(1);
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('a'));
+
+  EXPECT_EQ(c.get(), std::string("a"));
+
+  // Clear data
+  c.clear();
+
+  EXPECT_EQ(c.get(), std::string(""));
+
+  // Insert new char
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('b'));
+
+  EXPECT_EQ(c.get(), std::string("b"));
+
+  releaseSerialMock();
+}
+
+
+TEST(serial, stringCapture2) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(5);
+  EXPECT_CALL(*serialMock, write(Matcher<const uint8_t *>(_), Matcher<size_t>(_)))
+              .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
+  EXPECT_EQ(1, Serial.write((const uint8_t*)"abcde", 5));
+
+  EXPECT_EQ(c.get(), std::string("abcde"));
+
+}
+
+
+TEST(serial, stringCapture3) {
+  // Insert char first time
+  SerialMock* serialMock = serialMockInstance();
+  stringCapture c;
+
+  testing::DefaultValue<uint8_t>::Set(1);
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('a'));
+
+  EXPECT_EQ(c.get(), std::string("a"));
+
+  // Insert new char
+  EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
+              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+  EXPECT_EQ(1, Serial.write('b'));
+
+  EXPECT_EQ(c.get(), std::string("ab"));
+
   releaseSerialMock();
 }

--- a/test/serial_unittest.cc
+++ b/test/serial_unittest.cc
@@ -17,7 +17,7 @@ using ::testing::Invoke;
 TEST(serial, println1) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, println(1, 10))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(1, 10));
   releaseSerialMock();
 }
@@ -27,7 +27,7 @@ TEST(serial, println2) {
   SerialMock* serialMock = serialMockInstance();
   const char lala[] = "haha";
   EXPECT_CALL(*serialMock, println(lala))
-          .WillRepeatedly(Return(4));
+    .WillRepeatedly(Return(4));
   EXPECT_EQ(4, Serial.println(lala));
   releaseSerialMock();
 }
@@ -37,7 +37,7 @@ TEST(serial, println3) {
   SerialMock* serialMock = serialMockInstance();
   char lala = 'a';
   EXPECT_CALL(*serialMock, println(lala))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala));
   releaseSerialMock();
 }
@@ -47,7 +47,7 @@ TEST(serial, println4) {
   SerialMock* serialMock = serialMockInstance();
   unsigned char lala = 'a';
   EXPECT_CALL(*serialMock, println(lala, DEC))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala));
   releaseSerialMock();
 }
@@ -57,7 +57,7 @@ TEST(serial, println5) {
   SerialMock* serialMock = serialMockInstance();
   unsigned int lala = 1234;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -67,7 +67,7 @@ TEST(serial, println6) {
   SerialMock* serialMock = serialMockInstance();
   long lala = 1234567;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -77,7 +77,7 @@ TEST(serial, println7) {
   SerialMock* serialMock = serialMockInstance();
   unsigned long lala = 2345678;
   EXPECT_CALL(*serialMock, println(lala, DEC))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, DEC));
   releaseSerialMock();
 }
@@ -87,7 +87,7 @@ TEST(serial, println8) {
   SerialMock* serialMock = serialMockInstance();
   double lala = 3.14;
   EXPECT_CALL(*serialMock, println(lala, 2))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println(lala, 2));
   releaseSerialMock();
 }
@@ -96,7 +96,7 @@ TEST(serial, println8) {
 TEST(serial, println9) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, println())
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.println());
   releaseSerialMock();
 }
@@ -106,7 +106,7 @@ TEST(serial, print1) {
   SerialMock* serialMock = serialMockInstance();
   int lala = 123;
   EXPECT_CALL(*serialMock, print(Matcher<int>(lala), Matcher<int>(10)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, 10));
   releaseSerialMock();
 }
@@ -116,7 +116,7 @@ TEST(serial, print2) {
   SerialMock* serialMock = serialMockInstance();
   const char lala[] = "haha";
   EXPECT_CALL(*serialMock, print(Matcher<const char*>(lala)))
-          .WillRepeatedly(Return(4));
+    .WillRepeatedly(Return(4));
   EXPECT_EQ(4, Serial.print(lala));
   releaseSerialMock();
 }
@@ -126,7 +126,7 @@ TEST(serial, print3) {
   SerialMock* serialMock = serialMockInstance();
   char lala = 'a';
   EXPECT_CALL(*serialMock, print(Matcher<char>(lala)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala));
   releaseSerialMock();
 }
@@ -136,7 +136,7 @@ TEST(serial, print4) {
   SerialMock* serialMock = serialMockInstance();
   unsigned char lala = 'a';
   EXPECT_CALL(*serialMock, print(Matcher<unsigned char>(lala), Matcher<int>(DEC)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala));
   releaseSerialMock();
 }
@@ -146,7 +146,7 @@ TEST(serial, print5) {
   SerialMock* serialMock = serialMockInstance();
   unsigned int lala = 1234;
   EXPECT_CALL(*serialMock, print(Matcher<unsigned int>(lala), Matcher<int>(DEC)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -156,7 +156,7 @@ TEST(serial, print6) {
   SerialMock* serialMock = serialMockInstance();
   long lala = 1234567;
   EXPECT_CALL(*serialMock, print(Matcher<long>(lala), Matcher<int>(DEC)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -166,7 +166,7 @@ TEST(serial, print7) {
   SerialMock* serialMock = serialMockInstance();
   unsigned long lala = 2345678;
   EXPECT_CALL(*serialMock, print(Matcher<unsigned long>(lala), Matcher<int>(DEC)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, DEC));
   releaseSerialMock();
 }
@@ -176,7 +176,7 @@ TEST(serial, print8) {
   SerialMock* serialMock = serialMockInstance();
   double lala = 3.14;
   EXPECT_CALL(*serialMock, print(Matcher<double>(lala), Matcher<int>(2)))
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.print(lala, 2));
   releaseSerialMock();
 }
@@ -198,7 +198,7 @@ TEST(serial, write1) {
 TEST(serial, available) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, available())
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.available());
   releaseSerialMock();
 }
@@ -206,7 +206,7 @@ TEST(serial, available) {
 TEST(serial, read1) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, read())
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
   releaseSerialMock();
 }
@@ -214,7 +214,7 @@ TEST(serial, read1) {
 TEST(serial, read2) {
   SerialMock* serialMock = serialMockInstance();
   EXPECT_CALL(*serialMock, read())
-          .WillRepeatedly(Return(1));
+    .WillRepeatedly(Return(1));
   EXPECT_EQ(1, Serial.read());
   releaseSerialMock();
 }
@@ -227,7 +227,7 @@ TEST(serial, stringCapture1) {
 
   testing::DefaultValue<uint8_t>::Set(1);
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('a'));
 
   EXPECT_EQ(c.get(), std::string("a"));
@@ -239,7 +239,7 @@ TEST(serial, stringCapture1) {
 
   // Insert new char
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('b'));
 
   EXPECT_EQ(c.get(), std::string("b"));
@@ -255,7 +255,7 @@ TEST(serial, stringCapture2) {
 
   testing::DefaultValue<uint8_t>::Set(5);
   EXPECT_CALL(*serialMock, write(Matcher<const uint8_t *>(_), Matcher<size_t>(_)))
-              .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
+    .WillRepeatedly(Invoke(&c, &stringCapture::captureCStr));
   EXPECT_EQ(1, Serial.write((const uint8_t*)"abcde", 5));
 
   EXPECT_EQ(c.get(), std::string("abcde"));
@@ -270,14 +270,14 @@ TEST(serial, stringCapture3) {
 
   testing::DefaultValue<uint8_t>::Set(1);
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('a'));
 
   EXPECT_EQ(c.get(), std::string("a"));
 
   // Insert new char
   EXPECT_CALL(*serialMock, write(Matcher<uint8_t>(_)))
-              .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
+    .WillRepeatedly(Invoke(&c, &stringCapture::captureUInt8));
   EXPECT_EQ(1, Serial.write('b'));
 
   EXPECT_EQ(c.get(), std::string("ab"));


### PR DESCRIPTION
Added mocking for:
* Serial::read,  
* Serial::available, 
* Serial::write
* A new helper class stringCapture which simplifies getting all data from Serial functions, or other functions for that matter. This helps when testing code with arbitrary number of calls to Serial functions, but where the "sent" string is known (ie, you know how the protocol should look, but don't care how it is created). 

Unit tests are added for almost all functionality, and also updated to cover all print/println functions. 