### PR TITLE
Adding Stream and Print headers to compile Arduino code that depends on them

### DIFF
--- a/include/arduino-mock/Print.h
+++ b/include/arduino-mock/Print.h
@@ -1,0 +1,62 @@
+
+#ifndef Print_h
+#define Print_h
+
+#include <inttypes.h>
+#include <stdio.h> // for size_t
+
+#define DEC 10
+#define HEX 16
+#define OCT 8
+#define BIN 2
+
+class Print {
+    // private:
+    //   int write_error;
+    //   size_t printNumber(unsigned long, uint8_t);
+    //   size_t printFloat(double, uint8_t);
+    // protected:
+    //   void setWriteError(int err = 1) { write_error = err; }
+  public:
+    //   Print() : write_error(0) {}
+    //
+    //   int getWriteError() { return write_error; }
+    //   void clearWriteError() { setWriteError(0); }
+    //
+    // virtual size_t write(uint8_t) = 0;
+    //   size_t write(const char *str) {
+    //     if (str == NULL) return 0;
+    //     return write((const uint8_t *)str, strlen(str));
+    //   }
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    //   size_t write(const char *buffer, size_t size) {
+    //     return write((const uint8_t *)buffer, size);
+    //   }
+    //
+    //   size_t print(const __FlashStringHelper *);
+    //   size_t print(const String &);
+    //   size_t print(const char[]);
+    //   size_t print(char);
+    //   size_t print(unsigned char, int = DEC);
+    //   size_t print(int, int = DEC);
+    //   size_t print(unsigned int, int = DEC);
+    //   size_t print(long, int = DEC);
+    //   size_t print(unsigned long, int = DEC);
+    //   size_t print(double, int = 2);
+    //   size_t print(const Printable&);
+    //
+    //   size_t println(const __FlashStringHelper *);
+    //   size_t println(const String &s);
+    //   size_t println(const char[]);
+    //   size_t println(char);
+    //   size_t println(unsigned char, int = DEC);
+    //   size_t println(int, int = DEC);
+    //   size_t println(unsigned int, int = DEC);
+    //   size_t println(long, int = DEC);
+    //   size_t println(unsigned long, int = DEC);
+    //   size_t println(double, int = 2);
+    //   size_t println(const Printable&);
+    //   size_t println(void);
+};
+
+#endif

--- a/include/arduino-mock/Stream.h
+++ b/include/arduino-mock/Stream.h
@@ -1,0 +1,78 @@
+#ifndef STREAM_H
+#define STREAM_H
+
+#include "Print.h"
+#include <gmock/gmock.h>
+
+class Stream : public Print {
+  public:
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual int peek() = 0;
+    virtual void flush() = 0;
+    // virtual void setTimeout(unsigned long timeout);
+
+    virtual bool find(char *target) = 0;
+    virtual bool find(uint8_t *target) = 0;
+
+    virtual bool find(char *target, size_t length) = 0;
+    virtual bool find(uint8_t *target, size_t length) = 0;
+
+    // virtual bool findUntil(char *target, char *terminator) = 0;
+    // virtual bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator) = 0; }
+    //
+    // virtual bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen) = 0;
+    // virtual bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen) = 0; }
+    //
+    // virtual long parseInt() = 0;
+    //
+    // virtual float parseFloat() = 0;
+
+    virtual size_t readBytes( char *buffer, size_t length) = 0;
+    virtual size_t readBytes( uint8_t *buffer, size_t length) = 0;
+
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+
+    // virtual size_t readBytesUntil( char terminator, char *buffer, size_t length);
+    // virtual size_t readBytesUntil( char terminator, uint8_t *buffer, size_t length) { return readBytesUntil(terminator, (char *)buffer, length); }
+    //
+    // virtual String readString();
+    // virtual String readStringUntil(char terminator);
+
+};
+
+class StreamMock : public Stream {
+  public:
+    MOCK_METHOD0(available, int ());
+    MOCK_METHOD0(read, int ());
+    MOCK_METHOD0(peek, int ());
+    MOCK_METHOD0(flush, void ());
+
+    MOCK_METHOD1(find, bool (char *target));
+    MOCK_METHOD1(find, bool (uint8_t *target));
+    MOCK_METHOD2(find, bool (char *target, size_t length));
+    MOCK_METHOD2(find, bool (uint8_t *target, size_t length));
+
+    // virtual bool findUntil(char *target, char *terminator);
+    // virtual bool findUntil(uint8_t *target, char *terminator) { return findUntil((char *)target, terminator); }
+    //
+    // virtual bool findUntil(char *target, size_t targetLen, char *terminate, size_t termLen);
+    // virtual bool findUntil(uint8_t *target, size_t targetLen, char *terminate, size_t termLen) {return findUntil((char *)target, targetLen, terminate, termLen); }
+    //
+    // virtual long parseInt();
+    //
+    // virtual float parseFloat();
+    MOCK_METHOD2(readBytes, size_t (char *buffer, size_t length));
+    MOCK_METHOD2(readBytes, size_t (uint8_t *buffer, size_t length));
+
+    // virtual size_t readBytesUntil( char terminator, char *buffer, size_t length);
+    // virtual size_t readBytesUntil( char terminator, uint8_t *buffer, size_t length) { return readBytesUntil(terminator, (char *)buffer, length); }
+    //
+    // virtual String readString();
+    // virtual String readStringUntil(char terminator);
+
+    //Print functions
+    MOCK_METHOD2(write, size_t (const uint8_t*, size_t size));
+};
+
+#endif


### PR DESCRIPTION
Hey, this is Aaron from Octoblu!

The fork of your project we've been using has changed the directory structure a lot (for the worse; we're just standardizing on the arduino-style library format), but I figured you might be interested in these headers, at least.

They aren't full-fledged mocks, but at least they allow someone to compile Arduino code that is dependent on streams or print classes with them.

Embarassingly, I did implement a mock for Stream, and still have the unit tests for it, but can't seem to find them in my source tree. I'll PR the tests and implementation when I find them as well.
