### PR TITLE
Support for lighting controller code

### DIFF
--- a/include/arduino-mock/Arduino.h
+++ b/include/arduino-mock/Arduino.h
@@ -77,7 +77,42 @@ void loop(void);
 #define F(x) (x)
 
 class ArduinoMock {
+  private:
+    unsigned long  currentMillis;
+
   public:
+    ArduinoMock();
+
+    unsigned long getMillis() {
+      return currentMillis;
+    };
+
+    void setMillisRaw (unsigned long milliseconds) {
+      currentMillis = milliseconds;
+    };
+    void setMillisSecs(unsigned long seconds) {
+      setMillisRaw(seconds *      1000);
+    };
+    void setMillisMins(unsigned long minutes) {
+      setMillisRaw(minutes *   60 * 1000);
+    };
+    void setMillisHrs (float         hours)   {
+      setMillisRaw(hours  * 60 * 60 * 1000);
+    };
+
+    void addMillisRaw (unsigned long milliseconds) {
+      currentMillis += milliseconds;
+    };
+    void addMillisSecs(unsigned long seconds) {
+      addMillisRaw(seconds *      1000);
+    };
+    void addMillisMins(unsigned long minutes) {
+      addMillisRaw(minutes *   60 * 1000);
+    };
+    void addMillisHrs (float         hours)   {
+      addMillisRaw(hours  * 60 * 60 * 1000);
+    };
+
     MOCK_METHOD2(pinMode, void (uint8_t, uint8_t));
     MOCK_METHOD2(analogWrite, void (uint8_t, int));
     MOCK_METHOD2(digitalWrite, void (uint8_t, uint8_t));

--- a/include/arduino-mock/IRremote.h
+++ b/include/arduino-mock/IRremote.h
@@ -1,6 +1,11 @@
 /**
  * Arduino IRremote mock
+ * Used to mock out IRremote.h, an Arduino infrared remote library.
+ * For info on IRremote, see Ken Shirriff's blog article:
+ *   http://www.righto.com/2009/08/multi-protocol-infrared-remote-library.html
+ *   Note that Ken's latest code is now at https://github.com/shirriff/Arduino-IRremote
  */
+
 #ifndef IRremote_h
 #define IRremote_h
 

--- a/include/arduino-mock/IRremote.h
+++ b/include/arduino-mock/IRremote.h
@@ -1,0 +1,56 @@
+/**
+ * Arduino IRremote mock
+ */
+#ifndef IRremote_h
+#define IRremote_h
+
+#include <stdint.h>
+#include <gmock/gmock.h>
+
+class decode_results {
+  public:
+    decode_results();
+    int16_t decode_type; // NEC, SONY, RC5, UNKNOWN
+    uint16_t panasonicAddress; // This is only used for decoding Panasonic data
+    uint32_t value; // Decoded value
+    int16_t bits; // Number of bits in decoded value
+    volatile uint32_t *rawbuf; // Raw intervals in .5 us ticks
+    int16_t rawlen; // Number of records in rawbuf.
+};
+
+class IRrecvMock {
+  private:
+    uint32_t irValue;
+
+  public:
+    IRrecvMock();
+
+    void setIRValue(uint32_t value) {
+      irValue = value;
+    };
+    uint32_t getIRValue() {
+      return irValue;
+    };
+
+    MOCK_METHOD1(decode, int16_t (decode_results *));
+    MOCK_METHOD0(enableIRIn, void ());
+    MOCK_METHOD0(resume, void ());
+};
+
+class IRrecv_ {
+  public:
+    IRrecv_(int16_t recvpin);
+
+    int16_t decode(decode_results *results);
+    void enableIRIn();
+    void resume();
+
+    int16_t recvPin;
+};
+
+typedef IRrecv_ IRrecv;
+
+IRrecvMock* irrecvMockInstance();
+void releaseIRrecvMock();
+
+#endif // IRremote_h

--- a/include/arduino-mock/Serial.h
+++ b/include/arduino-mock/Serial.h
@@ -51,6 +51,13 @@ class SerialMock {
 };
 
 class Serial_ {
+
+  private:
+    static bool printToCout;
+
+  public:
+    static void setPrintToCout(bool flag);
+
   public:
     static size_t print(const char[]);
     static size_t print(char);

--- a/src/Arduino.cc
+++ b/src/Arduino.cc
@@ -1,4 +1,3 @@
-
 #include "arduino-mock/Arduino.h"
 
 static ArduinoMock* arduinoMock = NULL;
@@ -8,6 +7,7 @@ ArduinoMock* arduinoMockInstance() {
   }
   return arduinoMock;
 }
+
 void releaseArduinoMock() {
   if(arduinoMock) {
     delete arduinoMock;
@@ -15,35 +15,49 @@ void releaseArduinoMock() {
   }
 }
 
+ArduinoMock::ArduinoMock() {
+  currentMillis = 0;
+}
+
 void pinMode(uint8_t a, uint8_t b) {
+  assert (arduinoMock != NULL);
   arduinoMock->pinMode(a, b);
 }
 void digitalWrite(uint8_t a, uint8_t b) {
+  assert (arduinoMock != NULL);
   arduinoMock->digitalWrite(a, b);
 }
 
 int digitalRead(uint8_t a) {
+  assert (arduinoMock != NULL);
   return arduinoMock->digitalRead(a);
 }
 
 int analogRead(uint8_t a) {
+  assert (arduinoMock != NULL);
   return arduinoMock->analogRead(a);
 }
+
 void analogReference(uint8_t mode) {
   UNUSED(mode);
 }
 
 void analogWrite(uint8_t a, int b) {
+  assert (arduinoMock != NULL);
   arduinoMock->analogWrite(a, b);
 }
 
 unsigned long millis(void) {
-  return arduinoMock->millis();
+  assert (arduinoMock != NULL);
+  arduinoMock->millis();
+  return arduinoMock->getMillis();
 }
+
 unsigned long micros(void) {
   return 0;
 }
 void delay(unsigned long a) {
+  assert (arduinoMock != NULL);
   arduinoMock->delay(a);
 }
 void delayMicroseconds(unsigned int us) {

--- a/src/ArduinoMockAll.cc
+++ b/src/ArduinoMockAll.cc
@@ -9,3 +9,4 @@
 #include "Wire.cc"
 #include "SPI.cc"
 
+#include "IRremote.cc

--- a/src/ArduinoMockAll.cc
+++ b/src/ArduinoMockAll.cc
@@ -9,4 +9,4 @@
 #include "Wire.cc"
 #include "SPI.cc"
 
-#include "IRremote.cc
+#include "IRremote.cc"

--- a/src/EEPROM.cc
+++ b/src/EEPROM.cc
@@ -11,6 +11,7 @@ EEPROMMock* EEPROMMockInstance() {
 }
 
 void releaseEEPROMMock() {
+  assert (p_EEPROMMock != NULL);
   if (p_EEPROMMock) {
     delete p_EEPROMMock;
     p_EEPROMMock = NULL;
@@ -18,10 +19,12 @@ void releaseEEPROMMock() {
 }
 
 uint8_t EEPROM_::read(int a) {
+  assert (p_EEPROMMock != NULL);
   return p_EEPROMMock->read(a);
 }
 
 void EEPROM_::write(int a, uint8_t b) {
+  assert (p_EEPROMMock != NULL);
   p_EEPROMMock->write(a, b);
 }
 

--- a/src/IRremote.cc
+++ b/src/IRremote.cc
@@ -1,0 +1,58 @@
+#include "arduino-mock/IRremote.h"
+
+// Taken from IRremoteInt.h
+#define ERR 0
+#define DECODED 1
+
+static IRrecvMock* gIRrecvMock = NULL;
+IRrecvMock* irrecvMockInstance() {
+  if(!gIRrecvMock) {
+    gIRrecvMock = new IRrecvMock();
+  }
+  return gIRrecvMock;
+}
+
+void releaseIRrecvMock() {
+  if(gIRrecvMock) {
+    delete gIRrecvMock;
+    gIRrecvMock = NULL;
+  }
+}
+
+IRrecvMock::IRrecvMock() {
+  irValue = 0;
+}
+
+decode_results::decode_results() {
+  decode_type = 0;
+  panasonicAddress = 0;
+  value = 0;
+  bits = 0;
+  rawbuf = NULL;
+  rawlen = 0;
+}
+
+IRrecv_::IRrecv_(int16_t recvpin) {
+  recvPin = recvpin;
+}
+
+int16_t IRrecv_::decode(decode_results *results) {
+  assert (gIRrecvMock != NULL);
+  gIRrecvMock->decode(results);
+  assert (results != NULL);
+  results->value = gIRrecvMock->getIRValue();
+  return DECODED;
+}
+
+void IRrecv_::enableIRIn() {
+  assert (gIRrecvMock != NULL);
+  gIRrecvMock->enableIRIn();
+}
+
+void IRrecv_::resume() {
+  assert (gIRrecvMock != NULL);
+  gIRrecvMock->resume();
+}
+
+//// Preinstantiate Objects
+//IRrecv_ IRrecv;

--- a/src/Serial.cc
+++ b/src/Serial.cc
@@ -17,99 +17,206 @@ void releaseSerialMock() {
   }
 }
 
+// Serial.print(78, BIN) gives "1001110"
+// Serial.print(78, OCT) gives "116"
+// Serial.print(78, DEC) gives "78"
+// Serial.print(78, HEX) gives "4E"
+// Serial.println(1.23456, 0) gives "1"
+// Serial.println(1.23456, 2) gives "1.23"
+// Serial.println(1.23456, 4) gives "1.2346"
+
+void printDouble(double num, int digits) {
+  std::streamsize ss = std::cout.precision();
+  std::cout << std::setprecision(digits) << std::fixed << num;
+  std::cout.unsetf(std::ios::fixed);
+  std::cout.precision (ss);
+}
+
+template<typename T> void printBase(T num, int base) {
+  switch (base) {
+  case BIN:
+    assert (! "Need to implement this");
+    break;
+  case OCT:
+    std::cout << std::oct;
+    break;
+  case DEC:
+    std::cout << std::dec;
+    break;
+  case HEX:
+    std::cout << std::hex;
+    break;
+  }
+  std::cout << num << std::dec;
+}
+
+bool Serial_::printToCout = false;
+
+void Serial_::setPrintToCout(bool flag) {
+  printToCout = flag;
+}
+
 size_t Serial_::print(const char *s) {
+  if (printToCout) {
+    std::cout << s;
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(s);
 }
 
 size_t Serial_::print(char c) {
+  if (printToCout) {
+    std::cout << c;
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(c);
 }
 
 size_t Serial_::print(unsigned char c, int base) {
+  if (printToCout) {
+    printBase(c, base);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(c, base);
 }
 
 size_t Serial_::print(int num, int base) {
+  if (printToCout) {
+    printBase(num, base);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(num, base);
 }
 
 size_t Serial_::print(unsigned int num, int base) {
+  if (printToCout) {
+    printBase(num, base);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(num, base);
 }
 
 size_t Serial_::print(long num, int base) {
+  if (printToCout) {
+    printBase(num, base);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(num, base);
 }
 
 size_t Serial_::print(unsigned long num, int base) {
+  if (printToCout) {
+    printBase(num, base);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(num, base);
 }
 
 size_t Serial_::print(double num, int digits) {
+  if (printToCout) {
+    printDouble(num, digits);
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->print(num, digits);
 }
 
 size_t Serial_::println(const char *s) {
+  if (printToCout) {
+    std::cout << s << std::endl;
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->println(s);
 }
 
 size_t Serial_::println(char c) {
+  if (printToCout) {
+    std::cout << c << std::endl;
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->println(c);
 }
 
 size_t Serial_::println(unsigned char c, int base) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(c, base);
 }
 
 size_t Serial_::println(int num, int base) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(num, base);
 }
 
 size_t Serial_::println(unsigned int num, int base) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(num, base);
 }
 
 size_t Serial_::println(long num, int base) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(num, base);
 }
 
 size_t Serial_::println(unsigned long num, int base) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(num, base);
 }
 
 size_t Serial_::println(double num, int digits) {
+  assert (gSerialMock != NULL);
   return gSerialMock->println(num, digits);
 }
 
 size_t Serial_::println(void) {
+  if (printToCout) {
+    std::cout << std::endl;
+    return 0;
+  }
+  assert (gSerialMock != NULL);
   return gSerialMock->println();
 }
 
 size_t Serial_::write(uint8_t val) {
+  assert (gSerialMock != NULL);
   return gSerialMock->write(val);
 }
 
 size_t Serial_::write(const char *str) {
+  assert (gSerialMock != NULL);
   return gSerialMock->write(str);
 }
 
 size_t Serial_::write(const uint8_t *buffer, size_t size) {
+  assert (gSerialMock != NULL);
   return gSerialMock->write(buffer, size);
 }
 
 uint8_t Serial_::begin(uint32_t port) {
+  assert (gSerialMock != NULL);
   return gSerialMock->begin(port);
 }
 
 void Serial_::flush() {
+  assert (gSerialMock != NULL);
   return gSerialMock->flush();
 }
 
 uint8_t Serial_::available() {
+  assert (gSerialMock != NULL);
   return gSerialMock->available();
 }
 
 uint8_t Serial_::read() {
+  assert (gSerialMock != NULL);
   return gSerialMock->read();
 }
 


### PR DESCRIPTION
First off, thank you so much for arduino-mock, it was a godsend when I was developing code for the [lighting controller](http://hackaday.com/2014/11/14/powering-your-f-16-with-an-arduino/) I wrote for Arduino.  Here is a brain-dump of the modifications I made:

- One of the biggest things I did was add the ability to quickly set and advance the value returned by millis().  My code requires a lot of time counter based calculations thus for testing it was imperative that I be able to set and advance the milliseconds.
- I added a bunch of asserts for NULL pointers in a lot of the functions as forgetting to initialize the mocks bit me a lot.  It is a lot quicker to identify the problem when the assert points you to it instead of tracking down a segfault.  
- I added the IRremote mock as I needed it.  Basically copying from one of the existing mocks.
- In Serial.h I added the ability to print directly to cout instead of sending it back via the normal return mechanisms to aid in debugging